### PR TITLE
Feature/separate control and broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Set up the GSI's by running:
 ```shell
 aws dynamodb update-table \
 --table-name agha-aai-test-bed-local-dev \
---attribute-definitions AttributeName=modelId,AttributeType=S \
---global-secondary-index-updates \
- '{"Create":{"IndexName":"uidIndex","KeySchema":[{"AttributeName":"modelId","KeyType":"HASH"}],"ProvisionedThroughput":{"ReadCapacityUnits":10,"WriteCapacityUnits":5},"Projection":{"ProjectionType":"ALL"}}}' --endpoint-url http://localhost:8000
+--attribute-definitions AttributeName=modelId,AttributeType=S AttributeName=uid,AttributeType=S \
+    --global-secondary-index-updates \
+     '{"Create":{"IndexName":"uidIndex","KeySchema":[{"AttributeName":"uid","KeyType":"HASH"}],"ProvisionedThroughput":{"ReadCapacityUnits":10,"WriteCapacityUnits":5},"Projection":{"ProjectionType":"ALL"}}}' --endpoint-url http://localhost:8000
 ```
 
 ```shell

--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["src", ".env"],
   "ext": "js,ts,json",
   "ignore": ["src/**/*.spec.ts", "src/**/*.test.ts"],
-  "exec": "node --experimental-specifier-resolution=node --loader ts-node/esm --require dotenv/config src/bootstrap-local.ts"
+  "exec": "node --experimental-specifier-resolution=node --loader ts-node/esm --require dotenv/config src/bootstrap-control.ts"
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,7 +27,6 @@
         "ejs": "^3.1.6",
         "envalid": "^7.2.2",
         "express": "^4.17.1",
-        "got": "^12.0.1",
         "handlebars": "^4.7.7",
         "helmet": "^5.0.2",
         "hpp": "^0.2.3",
@@ -41,13 +40,12 @@
         "node-forge": "1.2.1",
         "oidc-provider": "7.10.6",
         "parseurl": "^1.3.3",
-        "pug": "^3.0.2",
-        "serve-favicon": "^2.5.0"
+        "pug": "^3.0.2"
       },
       "devDependencies": {
         "@types/compression": "^1.7.0",
         "@types/cookie-parser": "^1.4.2",
-        "@types/cors": "^2.8.10",
+        "@types/cors": "^2.8.12",
         "@types/express": "^4.17.11",
         "@types/hpp": "^0.2.1",
         "@types/jsonwebtoken": "^8.5.1",
@@ -57,10 +55,9 @@
         "@types/node-forge": "^1.0.0",
         "@types/oidc-provider": "^7.8.1",
         "@types/pug": "^2.0.6",
-        "@types/serve-favicon": "^2.5.3",
         "cross-env": "^7.0.3",
         "nodemon": "2.0.15",
-        "prettier": "^2.2.1",
+        "prettier": "2.5.1",
         "ts-node": "10.7.0",
         "typescript": "4.6.2"
       }
@@ -1097,17 +1094,6 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-      "dependencies": {
-        "defer-to-connect": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -1388,15 +1374,6 @@
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-favicon": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.3.tgz",
-      "integrity": "sha512-HirXLRJjLXzwiSnjhE1vMu55X7+qaY+noXsKqi/7eK1uByl3L6TwkcALZuJnQXqOalMdmBz3b662yXvaR+89Vw==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*"
       }
     },
     "node_modules/@types/serve-static": {
@@ -2585,11 +2562,6 @@
         }
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
-      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2677,54 +2649,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/got": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.0.1.tgz",
-      "integrity": "sha512-1Zhoh+lDej3t7Ks1BP/Jufn+rNqdiHQgUOcTxHzg2Dao1LQfp5S4Iq0T3iBxN4Zdo7QqCJL+WJUNzDX6rCP2Ew==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.2.0",
-        "@szmarczak/http-timer": "^5.0.1",
-        "@types/cacheable-request": "^6.0.2",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^6.0.4",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "form-data-encoder": "1.7.1",
-        "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.9",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^3.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/got/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/got/node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2859,18 +2783,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/http2-wrapper": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.10.tgz",
-      "integrity": "sha512-QHgsdYkieKp+6JbXP25P+tepqiHYd+FVnDwXpxi/BlUcoIB0nsmTOymTNvETuTO+pDuwcSklPE72VR3DqV+Haw==",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -3981,14 +3893,6 @@
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
     },
-    "node_modules/p-cancelable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/package-json": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
@@ -4626,31 +4530,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/serve-favicon": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
-      "integrity": "sha1-k10kDN/g9YBTB/3+ln2IlCosvPA=",
-      "dependencies": {
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "ms": "2.1.1",
-        "parseurl": "~1.3.2",
-        "safe-buffer": "5.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serve-favicon/node_modules/ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-    },
-    "node_modules/serve-favicon/node_modules/safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "node_modules/serve-static": {
       "version": "1.14.2",
@@ -6125,14 +6004,6 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.4.0.tgz",
       "integrity": "sha512-QppPM/8l3Mawvh4rn9CNEYIU9bxpXUCRMaX9yUpvBk1nMKusLKpfXGDEKExKaPhLzcn3lzil7pR6rnJ11HgeRQ=="
     },
-    "@szmarczak/http-timer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-      "requires": {
-        "defer-to-connect": "^2.0.1"
-      }
-    },
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -6413,15 +6284,6 @@
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/serve-favicon": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.3.tgz",
-      "integrity": "sha512-HirXLRJjLXzwiSnjhE1vMu55X7+qaY+noXsKqi/7eK1uByl3L6TwkcALZuJnQXqOalMdmBz3b662yXvaR+89Vw==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*"
       }
     },
     "@types/serve-static": {
@@ -7306,11 +7168,6 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
       "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
-    "form-data-encoder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
-      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
-    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7373,38 +7230,6 @@
       "dev": true,
       "requires": {
         "ini": "2.0.0"
-      }
-    },
-    "got": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.0.1.tgz",
-      "integrity": "sha512-1Zhoh+lDej3t7Ks1BP/Jufn+rNqdiHQgUOcTxHzg2Dao1LQfp5S4Iq0T3iBxN4Zdo7QqCJL+WJUNzDX6rCP2Ew==",
-      "requires": {
-        "@sindresorhus/is": "^4.2.0",
-        "@szmarczak/http-timer": "^5.0.1",
-        "@types/cacheable-request": "^6.0.2",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^6.0.4",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "form-data-encoder": "1.7.1",
-        "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.9",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^3.0.0",
-        "responselike": "^2.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-        },
-        "lowercase-keys": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-          "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="
-        }
       }
     },
     "graceful-fs": {
@@ -7495,15 +7320,6 @@
         "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
-      }
-    },
-    "http2-wrapper": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.10.tgz",
-      "integrity": "sha512-QHgsdYkieKp+6JbXP25P+tepqiHYd+FVnDwXpxi/BlUcoIB0nsmTOymTNvETuTO+pDuwcSklPE72VR3DqV+Haw==",
-      "requires": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.2.0"
       }
     },
     "iconv-lite": {
@@ -8370,11 +8186,6 @@
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
     },
-    "p-cancelable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw=="
-    },
     "package-json": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
@@ -8904,30 +8715,6 @@
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
-        }
-      }
-    },
-    "serve-favicon": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
-      "integrity": "sha1-k10kDN/g9YBTB/3+ln2IlCosvPA=",
-      "requires": {
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "ms": "2.1.1",
-        "parseurl": "~1.3.2",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "dev": " cross-env NODE_ENV=development nodemon",
+    "dev": "cross-env NODE_ENV=development nodemon",
+    "broker": "node --experimental-specifier-resolution=node --loader ts-node/esm --require dotenv/config src/bootstrap-local.ts",
     "build": "tsc --build",
     "watch": "tsc --build --watch"
   },
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@types/compression": "^1.7.0",
     "@types/cookie-parser": "^1.4.2",
+    "@types/cors": "^2.8.12",
     "@types/express": "^4.17.11",
     "@types/hpp": "^0.2.1",
     "@types/jsonwebtoken": "^8.5.1",

--- a/backend/src/app-broker/business/services/visa/sign-jwt.ts
+++ b/backend/src/app-broker/business/services/visa/sign-jwt.ts
@@ -7,18 +7,18 @@ import cryptoRandomString                      from "crypto-random-string";
  * @param protectedHeader
  * @param subjectId
  * @param issuer
- * @param expirationTime
+ * @param duration
  * @param rsaPrivateKey
  */
 export async function generateSignedJWT(claims: any, protectedHeader: JWTHeaderParameters
-    , subjectId: string, issuer: string | null, expirationTime: string, rsaPrivateKey: KeyLike | Uint8Array) {
+    , subjectId: string, issuer: string | null, duration: string | number, rsaPrivateKey: KeyLike | Uint8Array) {
     const newJwtSigner = new SignJWT(claims);
     newJwtSigner
         .setProtectedHeader(protectedHeader)
         .setSubject(subjectId)
         .setIssuedAt()
         .setIssuer(issuer!)
-        .setExpirationTime(expirationTime)
+        .setExpirationTime(duration)
         .setJti(cryptoRandomString({length: 16, type: 'alphanumeric'}));
 
     return await newJwtSigner.sign(rsaPrivateKey);

--- a/backend/src/bootstrap-control.ts
+++ b/backend/src/bootstrap-control.ts
@@ -1,0 +1,12 @@
+import {AppControl}    from "./app-control/app-control";
+import {setupTestData} from "./testing/setup-test-data";
+
+console.log('Bootstrapping local server for the control API');
+console.log('Creating Express app');
+
+const appControl = new AppControl();
+setupTestData().then(() => {
+    appControl.listen( 3454, () => {
+        console.log('Started control on 3454');
+    });
+})

--- a/backend/src/bootstrap-local.ts
+++ b/backend/src/bootstrap-local.ts
@@ -44,9 +44,9 @@ console.log(`Using valid fixture ${args[0]}}`)
 
 const fixture = await getFixture(args[0]);
 
-const appBrokerValid = new AppBroker(args[0], "not.used", fixture, true);
+const appBroker = new AppBroker(args[0], "not.used", fixture, true);
 
 // THIS IS NOT THE ENTRYPOINT FOR USE IN PRODUCTION WITHIN THE AWS LAMBDA ENVIRONMENT
-appBrokerValid.listen(3455, () => {
+appBroker.listen(3455, () => {
     console.log('Started local broker on 3455');
 })

--- a/backend/src/bootstrap-local.ts
+++ b/backend/src/bootstrap-local.ts
@@ -1,32 +1,52 @@
-import { setupTestData } from './testing/setup-test-data';
-import { AppBroker } from './app-broker/app-broker';
-import { AppControl } from './app-control/app-control';
-import { DynamoDBAdapter } from "./common/business/db/oidc-provider-dynamodb-adapter";
-import { getFixture } from "./common/business/fixture-payload";
+import {AppControl}    from './app-control/app-control';
+import {getFixture}    from "./common/business/fixture-payload";
+import {AppBroker}     from "./app-broker/app-broker";
+import {setupTestData} from "./testing/setup-test-data";
 
 // the development node bootstrap entrypoint
 // this entrypoint is used for running the backend locally on a dev machine - but must
 // still be done with AWS env variables set for permissions into the dev AWS
 
-console.log('Bootstrapping local server (broker and control)');
+// console.log('Bootstrapping local server (broker and control)');
+// console.log('Creating fresh test data');
+//
+// setupTestData().then(async (id: string) => {
+//   console.log('Creating Express app');
+//
+//   const fixture = await getFixture(id);
+//
+//   const appBroker = new AppBroker(id, "not.used", fixture, true);
+//
+//   // THIS IS NOT THE ENTRYPOINT FOR USE IN PRODUCTION WITHIN THE AWS LAMBDA ENVIRONMENT
+//   appBroker.listen(3000, () => {
+//     console.log('Started local broker on 3000');
+//
+//     // until we start using control no need to start it
+//     const appControl = new AppControl();
+//
+//     appControl.listen(3001, () => {
+//       console.log('Started control on 3001');
+//     });
+//   });
+// });
+
+// the development node bootstrap entrypoint
+// this entrypoint is used for running the backend locally on a dev machine - but must
+// still be done with AWS env variables set for permissions into the dev AWS
+
+console.log('Bootstrapping local server broker');
 console.log('Creating fresh test data');
+console.log('Creating Express app');
 
-setupTestData().then(async (id: string) => {
-  console.log('Creating Express app');
+const args = process.argv.slice(2)
 
-  const fixture = await getFixture(id);
+console.log(`Using valid fixture ${args[0]}}`)
 
-  const appBroker = new AppBroker(id, "not.used", fixture, true);
+const fixture = await getFixture(args[0]);
 
-  // THIS IS NOT THE ENTRYPOINT FOR USE IN PRODUCTION WITHIN THE AWS LAMBDA ENVIRONMENT
-  appBroker.listen(3000, () => {
-    console.log('Started local broker on 3000');
+const appBrokerValid = new AppBroker(args[0], "not.used", fixture, true);
 
-    // until we start using control no need to start it
-    const appControl = new AppControl();
-
-    appControl.listen(3001, () => {
-      console.log('Started control on 3001');
-    });
-  });
-});
+// THIS IS NOT THE ENTRYPOINT FOR USE IN PRODUCTION WITHIN THE AWS LAMBDA ENVIRONMENT
+appBrokerValid.listen(3455, () => {
+    console.log('Started local broker on 3455');
+})

--- a/backend/src/common/business/scenario/scenario-2022.ts
+++ b/backend/src/common/business/scenario/scenario-2022.ts
@@ -2,7 +2,7 @@ import {ScenarioData, ScenarioUser} from './scenario-data';
 
 export class Scenario2022 extends ScenarioData {
     private users: { [key: string]: ScenarioUser } = {
-        'http://uid.org/0': {
+        'noVisas': {
             sub: 'http://uid.org/0',
             name: 'Ted Lasso',
             roles: {
@@ -14,7 +14,7 @@ export class Scenario2022 extends ScenarioData {
             },
             expectedVisas: []
         },
-        'http://uid.org/1': {
+        'ControlledAccessGrant': {
             sub: 'http://uid.org/1',
             name: 'Tony Stark',
             roles: {
@@ -32,7 +32,7 @@ export class Scenario2022 extends ScenarioData {
                 'AcceptedTermsAndPoliciesVisa'
             ]
         },
-        'http://uid.org/2': {
+        'AffiliationAndRole': {
             sub: 'http://uid.org/2',
             name: 'Mary Jones',
             roles: {
@@ -47,7 +47,7 @@ export class Scenario2022 extends ScenarioData {
                 'AcceptedTermsAndPoliciesVisa'
             ]
         },
-        'http://uid.org/3': {
+        'LinkedIdentity': {
             sub: 'http://uid.org/3',
             name: 'Bruce Smith',
             roles: {
@@ -64,7 +64,7 @@ export class Scenario2022 extends ScenarioData {
                 'ResearcherStatus'
             ]
         },
-        'http://uid.org/4': {
+        'Clinician': {
             sub: 'http://uid.org/4',
             name: 'Bruce Smith',
             roles: {
@@ -81,7 +81,7 @@ export class Scenario2022 extends ScenarioData {
                 'ResearcherStatus'
             ]
         },
-        'http://uid.org/5': {
+        'Researcher': {
             sub: 'http://uid.org/5',
             name: 'Thor',
             roles: {
@@ -96,6 +96,62 @@ export class Scenario2022 extends ScenarioData {
                 'ResearcherStatus'
             ]
         },
+        'TermsAndPolicies': {
+            sub: 'http://uid.org/5',
+            name: 'Thor',
+            roles: {
+                institution: null,
+                dataset: null,
+                linkedIdentity: null,
+                termsAndPolicies: true,
+                researcherStatus: null
+            },
+            expectedVisas: [
+                'AcceptedTermsAndPoliciesVisa'
+            ]
+        },
+        'invalidVisaSignature': {
+            sub: 'invalidVisaSignature',
+            name: 'Tony Stark',
+            roles: {
+                institution: null,
+                dataset: null,
+                linkedIdentity: null,
+                termsAndPolicies: false,
+                researcherStatus: null
+            },
+            expectedVisas: [
+                'invalidVisaSignature'
+            ]
+        },
+        'expiredVisa': {
+            sub: 'expiredVisa',
+            name: 'Mary Jones',
+            roles: {
+                institution: null,
+                dataset: null,
+                linkedIdentity: null,
+                termsAndPolicies: false,
+                researcherStatus: null
+            },
+            expectedVisas: [
+                'expiredVisa'
+            ]
+        },
+        'invalidIssuer': {
+            sub: 'invalidIssuer',
+            name: 'Mary Jones',
+            roles: {
+                institution: null,
+                dataset: null,
+                linkedIdentity: null,
+                termsAndPolicies: false,
+                researcherStatus: null
+            },
+            expectedVisas: [
+                'invalidIssuer'
+            ]
+        }
     }
 
     override getUsers() {

--- a/backend/src/common/business/scenario/scenario-data.ts
+++ b/backend/src/common/business/scenario/scenario-data.ts
@@ -22,11 +22,11 @@ export abstract class ScenarioData {
   abstract getUsers(): { [key: string]: ScenarioUser };
 
   getUserSubjectIds(): string[] {
-    return Object.keys(this.getUsers())
+    return Object.keys(this.getUsers());
   }
 
   getUserById(sub: string): ScenarioUser {
-    return this.getUsers()[sub]
+    return this.getUsers()[sub];
   }
 
 }

--- a/backend/src/common/business/scenario/scenario-error.ts
+++ b/backend/src/common/business/scenario/scenario-error.ts
@@ -7,17 +7,13 @@ export class ScenarioError extends ScenarioData {
             name: 'Tony Stark',
             roles: {
                 institution: null,
-                dataset: {
-                    dataset: 'test-dataset',
-                    approvedAt: 1549632872
-                },
+                dataset: null,
                 linkedIdentity: null,
-                termsAndPolicies: true,
+                termsAndPolicies: false,
                 researcherStatus: null
             },
             expectedVisas: [
-                'ControlledAccessGrant',
-                'AcceptedTermsAndPoliciesVisa'
+                'invalidVisaSignature'
             ]
         },
         'expiredVisa': {
@@ -25,20 +21,30 @@ export class ScenarioError extends ScenarioData {
             name: 'Mary Jones',
             roles: {
                 institution: 'maryjones@test.com',
-                dataset: {
-                    dataset: 'test-dataset',
-                    approvedAt: 1549632872
-                },
+                dataset: null,
                 linkedIdentity: null,
-                termsAndPolicies: true,
+                termsAndPolicies: false,
                 researcherStatus: null
             },
             expectedVisas: [
-                'ControlledAccessGrant',
-                'AcceptedTermsAndPoliciesVisa'
+                'expiredVisa'
+            ]
+        },
+        'invalidIssuer': {
+            sub: 'invalidIssuer',
+            name: 'Mary Jones',
+            roles: {
+                institution: 'maryjones@test.com',
+                dataset: null,
+                linkedIdentity: null,
+                termsAndPolicies: false,
+                researcherStatus: null
+            },
+            expectedVisas: [
+                'invalidIssuer'
             ]
         }
-    }
+    };
 
     override getUsers() {
         return this.users

--- a/backend/src/testing/setup-test-data.ts
+++ b/backend/src/testing/setup-test-data.ts
@@ -97,7 +97,7 @@ export async function setupTestData(): Promise<string> {
           {
             client_id: clientId,
             client_secret: clientSecret,
-            redirect_uris: ['http://localhost:8888/callback'],
+            redirect_uris: ['http://localhost:4200/callback', 'http://localhost:8888/callback'],
           },
         ],
         jwks: { keys: [jwksKey] },
@@ -111,13 +111,6 @@ export async function setupTestData(): Promise<string> {
       },
       consentStage: {
         forceAccept: true
-      },
-      introduceErrors: {
-        expiredPassport: false,
-        expiredVisa: false,
-        invalidJwtAlgorithm: false,
-        invalidPassportSignature: false,
-        invalidVisaSignature: true
       }
     },
     3600,

--- a/client/flow_browser.py
+++ b/client/flow_browser.py
@@ -10,7 +10,7 @@ from server_wait_for_callback import create_code_wait_server, wait_code_wait_ser
 # Does an OIDC flow expecting to need to do some real in browser HTML login/interactions
 #
 
-ISSUER = "http://localhost:3000"
+ISSUER = "http://localhost:3455"
 CLIENT_ID = "client"
 CLIENT_SECRET = "secret"
 REDIRECT = "http://localhost:8888/callback"

--- a/client/flow_quiet.py
+++ b/client/flow_quiet.py
@@ -1,9 +1,9 @@
 import requests
-
+import sys
 from server_wait_for_callback import create_code_wait_server, wait_code_wait_server
 
-ISSUER = "http://localhost:3000"
-#ISSUER = "https://jtbpmjfzfjngtzqz.aai.nagim.dev"
+CONTROL = "http://localhost:3454"
+ISSUER = "http://localhost:3455"
 CLIENT_ID = "client"
 CLIENT_SECRET = "secret"
 REDIRECT = "http://localhost:8888/callback"
@@ -12,10 +12,29 @@ REDIRECT = "http://localhost:8888/callback"
 # Does an OIDC flow and finishes with a fetch of the userinfo endpoint
 #
 
-
-create_code_wait_server()
+print('Generating', sys.argv[1], 'visa')
 
 s = requests.Session()
+
+createFixture = s.post(
+    f"{CONTROL}/create",
+    data={
+        "scenario": "2022",
+        "forceSubject": sys.argv[1],
+        "forceAccept": True
+    },
+)
+
+fixtureId = createFixture.json()['id']
+
+setFixture = s.get(
+    f"{ISSUER}/setFixture",
+    params={
+        "fixtureId": fixtureId
+    }
+)
+
+create_code_wait_server()
 
 r = s.get(
     f"{ISSUER}/auth",
@@ -28,7 +47,6 @@ r = s.get(
     }
 )
 
-print(r)
 
 code = wait_code_wait_server()
 


### PR DESCRIPTION
Hi Andrew,

My thesis demo is on Wednesday, so I pulled this together with some ideas that I had that would be most useful and good for demo purposes. My thought process was that if a user wants to generate a new fixture, they should be able to easily update the fixture being used in the broker and generate visas from that fixture. So:

1. I fixed the create fixture endpoint in the control API
2. I added a way to set the fixture in the broker API
3. I separated the starting points for control API/broker API (control API shouldn't be reliant on broker API)
4. I updated `flow_quiet.py` so you can run it like `pipenv run python flow_quiet.py TermsAndPolicies`. This would create a new fixture where 'TermsAndPolicies' was the forced subject, and generate a single visa.

I also combined the two scenarios because I'm struggling to see how the different scenarios could be used easily, so now you only need one scenario to generate both a `ControlledAccessGrant` visa and an `InvalidIssuer` visa etc.

There's no rush on getting feedback etc, this is at a good point where it can be demoed and I think this would be really useful for someone to generate a single visa as they would need during testing, but would appreciate any feedback. Happy to keep working on this after my demo :)